### PR TITLE
fix: li elements NavList에서 감싸는 방식으로 변경

### DIFF
--- a/src/features/header/NavList.tsx
+++ b/src/features/header/NavList.tsx
@@ -23,12 +23,13 @@ export default function NavList() {
   return (
     <ul className="flex flex-col gap-5 lg:flex-row lg:items-center">
       {navList.map(nav => (
-        <TopTap
-          key={nav.path}
-          path={nav.path}
-          name={nav.name}
-          className="flex items-center gap-[5px]"
-        />
+        <li key={nav.path}>
+          <TopTap
+            path={nav.path}
+            name={nav.name}
+            className="flex items-center gap-[5px]"
+          />
+        </li>
       ))}
     </ul>
   );

--- a/src/features/header/top-tap/index.tsx
+++ b/src/features/header/top-tap/index.tsx
@@ -18,31 +18,29 @@ export default function TopTap({ path, name, className }: TopTapProps) {
   const { resetPopover } = useResponsiveGNBPopoverStore();
 
   return (
-    <li>
-      <Link
-        href={path}
-        className={cn(
-          `font-semibold text-gray-700 hover:text-green-500`,
-          className,
-          `${currentPathName === path ? 'text-green-500' : ''}`,
-        )}
-        onClick={() => resetPopover()}
-      >
-        <p>{name}</p>
-        {value > 0 && path === '/like-gatherings' && (
-          <CommonBadge count={value} />
-        )}
-        {name === '로그인이 필요합니다.' ? (
-          <Chevron
-            width="24"
-            height="24"
-            fill="#9F9F9F"
-            className="group-hover:fill-green-500"
-          />
-        ) : (
-          <></>
-        )}
-      </Link>
-    </li>
+    <Link
+      href={path}
+      className={cn(
+        `font-semibold text-gray-700 hover:text-green-500`,
+        className,
+        `${currentPathName === path ? 'text-green-500' : ''}`,
+      )}
+      onClick={() => resetPopover()}
+    >
+      <p>{name}</p>
+      {value > 0 && path === '/like-gatherings' && (
+        <CommonBadge count={value} />
+      )}
+      {name === '로그인이 필요합니다.' ? (
+        <Chevron
+          width="24"
+          height="24"
+          fill="#9F9F9F"
+          className="group-hover:fill-green-500"
+        />
+      ) : (
+        <></>
+      )}
+    </Link>
   );
 }


### PR DESCRIPTION
## PR타입

- [ ] 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 변경
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 수정

## 작업 내용(변경 사항)

- fix: li 태그로 인한 로그인 화면에 위치 변경되어서 li elements NavList에서 감싸는 방식으로 변경

## 테스트 결과

- [ ] 테스트 완료
